### PR TITLE
RIA-3835: Added Launch Darkly test client for functional tests to control the tests run to enable deployments

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,6 +16,7 @@ def secrets = [
 
         secret('idam-url', 'IDAM_URL'),
         secret('s2s-url', 'S2S_URL'),
+        secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
 
         secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
         secret('idam-secret', 'IA_IDAM_SECRET'),

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -29,6 +29,7 @@ def secrets = [
 
         secret('idam-url', 'IDAM_URL'),
         secret('s2s-url', 'S2S_URL'),
+        secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
 
         secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
         secret('idam-secret', 'IA_IDAM_SECRET'),

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -17,19 +17,20 @@ def secrets = [
     'ia-${env}': [
 
         secret('idam-url', 'IDAM_URL'),
-                secret('s2s-url', 'S2S_URL'),
+        secret('s2s-url', 'S2S_URL'),
+        secret('launch-darkly-sdk-key', 'LAUNCH_DARKLY_SDK_KEY'),
 
-                secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
-                secret('idam-secret', 'IA_IDAM_SECRET'),
-                secret('s2s-secret', 'IA_S2S_SECRET'),
-                secret('s2s-microservice', 'IA_S2S_MICROSERVICE'),
+        secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
+        secret('idam-secret', 'IA_IDAM_SECRET'),
+        secret('s2s-secret', 'IA_S2S_SECRET'),
+        secret('s2s-microservice', 'IA_S2S_MICROSERVICE'),
 
-                secret('test-caseofficer-username', 'TEST_CASEOFFICER_USERNAME'),
-                secret('test-caseofficer-password', 'TEST_CASEOFFICER_PASSWORD'),
-                secret('test-law-firm-a-username', 'TEST_LAW_FIRM_A_USERNAME'),
-                secret('test-law-firm-a-password', 'TEST_LAW_FIRM_A_PASSWORD'),
-                secret('test-adminofficer-username', 'TEST_ADMINOFFICER_USERNAME'),
-                secret('test-adminofficer-password', 'TEST_ADMINOFFICER_PASSWORD')
+        secret('test-caseofficer-username', 'TEST_CASEOFFICER_USERNAME'),
+        secret('test-caseofficer-password', 'TEST_CASEOFFICER_PASSWORD'),
+        secret('test-law-firm-a-username', 'TEST_LAW_FIRM_A_USERNAME'),
+        secret('test-law-firm-a-password', 'TEST_LAW_FIRM_A_PASSWORD'),
+        secret('test-adminofficer-username', 'TEST_ADMINOFFICER_USERNAME'),
+        secret('test-adminofficer-password', 'TEST_ADMINOFFICER_PASSWORD')
 
     ]
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,6 @@ dependencyCheck {
 
 dependencyManagement {
   dependencies {
-    dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.65'
     // CVE-2018-10237 - Unbounded memory allocation
     dependencySet(group: 'com.google.guava', version: '29.0-jre') {
       entry 'guava'
@@ -310,6 +309,7 @@ dependencies {
 
   testImplementation group: 'org.springframework.security', name: 'spring-security-test'
 
+  compile group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '4.14.1'
   testCompileOnly 'org.projectlombok:lombok:1.18.12'
   testAnnotationProcessor 'org.projectlombok:lombok:1.18.12'
 

--- a/charts/ia-home-office-integration-api/Chart.yaml
+++ b/charts/ia-home-office-integration-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: Helm chart for ia-home-office-integration-api microservice
 name: ia-home-office-integration-api
 home: https://github.com/hmcts/ia-home-office-integration-api
-version: 0.0.13
+version: 0.0.14
 maintainers:
   - name: HMCTS Immigration & Asylum Team
     email: ImmigrationandAsylum@HMCTS.NET

--- a/charts/ia-home-office-integration-api/values.yaml
+++ b/charts/ia-home-office-integration-api/values.yaml
@@ -19,3 +19,4 @@ java:
         - homeoffice-client-id
         - homeoffice-secret
         - AppInsightsInstrumentationKey
+        - launch-darkly-sdk-key

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -117,4 +117,40 @@
     ]]></notes>
         <cve>CVE-2020-8908</cve>
     </suppress>
+    <suppress until="2030-01-01">
+        <notes><![CDATA[
+             Shadowed dependency from launchdarkly-java-server-sdk.
+             This is specific to deserialisation of AtomicDoubleArray and CompoundOrdering classes: https://github.com/google/guava/wiki/CVE-2018-10237
+            ]]></notes>
+        <gav regex="true">^com\.google\.guava:guava:.*$</gav>
+        <cve>CVE-2018-10237</cve>
+    </suppress>
+    <suppress until="2099-06-01">
+        <notes><![CDATA[
+          It is vulnerability discovered in spring oauth2 module in transitive dependency (ignore for now)
+          more details https://nvd.nist.gov/vuln/detail/CVE-2020-29242
+    ]]></notes>
+        <cve>CVE-2020-29242</cve>
+    </suppress>
+    <suppress until="2099-06-01">
+        <notes><![CDATA[
+          It is vulnerability discovered in spring oauth2 module in transitive dependency (ignore for now)
+          more details https://nvd.nist.gov/vuln/detail/CVE-2020-29243
+    ]]></notes>
+        <cve>CVE-2020-29243</cve>
+    </suppress>
+    <suppress until="2099-06-01">
+        <notes><![CDATA[
+          It is vulnerability discovered in spring oauth2 module in transitive dependency (ignore for now)
+          more details https://nvd.nist.gov/vuln/detail/CVE-2020-29244
+    ]]></notes>
+        <cve>CVE-2020-29244</cve>
+    </suppress>
+    <suppress until="2099-06-01">
+        <notes><![CDATA[
+          It is vulnerability discovered in spring oauth2 module in transitive dependency (ignore for now)
+          more details https://nvd.nist.gov/vuln/detail/CVE-2020-29245
+    ]]></notes>
+        <cve>CVE-2020-29245</cve>
+    </suppress>
 </suppressions>

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/util/LaunchDarklyFunctionalTestClient.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/util/LaunchDarklyFunctionalTestClient.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.reform.iahomeofficeintegrationapi.util;
+
+import com.launchdarkly.client.LDClientInterface;
+import com.launchdarkly.client.LDUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientResponseException;
+import uk.gov.hmcts.reform.iahomeofficeintegrationapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.iahomeofficeintegrationapi.infrastructure.client.IdamApi;
+import uk.gov.hmcts.reform.iahomeofficeintegrationapi.infrastructure.client.model.idam.UserInfo;
+import uk.gov.hmcts.reform.iahomeofficeintegrationapi.infrastructure.security.idam.IdamUserDetails;
+import uk.gov.hmcts.reform.iahomeofficeintegrationapi.infrastructure.security.idam.IdentityManagerResponseException;
+
+@Component
+public class LaunchDarklyFunctionalTestClient {
+
+    @Autowired private IdamApi idamApi;
+    @Autowired private LDClientInterface ldClient;
+
+    public boolean getKey(String key, String accessToken) {
+
+        UserDetails userDetails = getUserDetails(accessToken);
+
+        LDUser ldUser =  new LDUser.Builder(userDetails.getId())
+            .firstName(userDetails.getForename())
+            .lastName(userDetails.getSurname())
+            .email(userDetails.getEmailAddress())
+            .build();
+
+        return ldClient.boolVariation(key, ldUser, false);
+    }
+
+    private IdamUserDetails getUserDetails(String accessToken) {
+        try {
+
+            UserInfo userInfo = idamApi.userInfo(accessToken);
+
+            return new IdamUserDetails(
+                accessToken,
+                userInfo.getUid(),
+                userInfo.getRoles(),
+                userInfo.getEmail(),
+                userInfo.getGivenName(),
+                userInfo.getFamilyName()
+            );
+
+        } catch (RestClientResponseException ex) {
+
+            throw new IdentityManagerResponseException(
+                "Could not get user details with IDAM",
+                ex
+            );
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/infrastructure/config/FeatureToggleConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/infrastructure/config/FeatureToggleConfiguration.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.iahomeofficeintegrationapi.infrastructure.config;
+
+import com.launchdarkly.client.Components;
+import com.launchdarkly.client.LDClient;
+import com.launchdarkly.client.LDClientInterface;
+import com.launchdarkly.client.LDConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeatureToggleConfiguration {
+
+    @Value("${launchDarkly.sdkKey}")
+    private String sdkKey;
+
+    @Value("${launchDarkly.connectionTimeout}")
+    private Integer connectionTimeout;
+
+    @Value("${launchDarkly.socketTimeout}")
+    private Integer socketTimeout;
+
+    @Bean
+    public LDConfig ldConfig() {
+        return new LDConfig.Builder()
+            .http(Components
+                .httpConfiguration()
+                .connectTimeoutMillis(connectionTimeout)
+                .socketTimeoutMillis(socketTimeout)
+            )
+            .build();
+    }
+
+    @Bean
+    public LDClientInterface ldClient(LDConfig ldConfig) {
+        return new LDClient(sdkKey, ldConfig);
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,6 +72,11 @@ idam:
   s2s-authorised:
     services: ${IA_S2S_AUTHORIZED_SERVICES:ccd,ccd_data,ccd_gw,ccd_ps,iac}
 
+launchDarkly:
+  sdkKey: ${LAUNCH_DARKLY_SDK_KEY:sdk-key}
+  connectionTimeout: 5
+  socketTimeout: 5
+
 home-office:
   api:
     url: ${HOME_OFFICE_ENDPOINT:http://localhost:8098}

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -14,3 +14,4 @@ spring:
         homeoffice-client-id: IA_HOMEOFFICE_CLIENT_ID
         homeoffice-secret: IA_HOMEOFFICE_SECRET
         AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key
+        launch-darkly-sdk-key: LAUNCH_DARKLY_SDK_KEY


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-3835


### Change description ###
Added Launch Darkly test client for functional tests to control the tests run to enable deployments


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X