### PR TITLE
RIA-6533 Added direction tag for ADA list case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/domain/entities/DirectionTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/domain/entities/DirectionTag.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum DirectionTag {
 
+    ADA_LIST_CASE("adaListCase"),
     BUILD_CASE("buildCase"),
     CASE_EDIT("caseEdit"),
     LEGAL_REPRESENTATIVE_REVIEW("legalRepresentativeReview"),

--- a/src/test/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/domain/entities/DirectionTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/domain/entities/DirectionTagTest.java
@@ -24,11 +24,12 @@ class DirectionTagTest {
         assertEquals("requestReasonsForAppeal", DirectionTag.REQUEST_REASONS_FOR_APPEAL.toString());
         assertEquals("requestClarifyingQuestions", DirectionTag.REQUEST_CLARIFYING_QUESTIONS.toString());
         assertEquals("requestCmaRequirements", DirectionTag.REQUEST_CMA_REQUIREMENTS.toString());
+        assertEquals("adaListCase", DirectionTag.ADA_LIST_CASE.toString());
         assertEquals("", DirectionTag.NONE.toString());
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(13, DirectionTag.values().length);
+        assertEquals(14, DirectionTag.values().length);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6533](https://tools.hmcts.net/jira/browse/RIA-6533)
A direction has to be created when an admin lists an ADA case (in `awaitingRespondentEvidence` state) and a notification with the same content has to be sent to the LR.

### Change description ###
Added ADA list case direction tag


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
