### PR TITLE
RIA-5679 changed suppression to fixed dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -314,6 +314,9 @@ dependencies {
   implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
   implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '6.2.1'
 
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.80'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.80'
+
   compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.28'
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.28'
   testCompileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.28'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,6 +24,5 @@
    They should still be addressed -->
     <suppress until="2023-09-30">
         <cve>CVE-2023-35116</cve><!-- 2023-09-04 Version 2.15.2 of jackson-databind is still vulnerable. Check again once a new version is available -->
-        <cve>CVE-2023-41080</cve><!-- 2023-09-05 Apache Tomcat vulnerability -->
     </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7386


### Change description ###
Removed suppression of CVE-2023-41080, added dependency for it with specific version without vulnerability


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
