### PR TITLE
RIA-7195 add the witnessPartyId and witnessFamilyName in WitnessDetails

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -28,6 +28,7 @@
     <suppress until="2024-03-01">
         <cve>CVE-2023-42794</cve>
         <cve>CVE-2023-42795</cve>
-        <cve>CVE-2023-45648</cve>        
+        <cve>CVE-2023-45648</cve>
+        <cve>CVE-2023-44487</cve>
     </suppress>    
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/domain/entities/ccd/WitnessDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/domain/entities/ccd/WitnessDetails.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.iahomeofficeintegrationapi.domain.entities.ccd;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter

--- a/src/main/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/domain/entities/ccd/WitnessDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/iahomeofficeintegrationapi/domain/entities/ccd/WitnessDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.iahomeofficeintegrationapi.domain.entities.ccd;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,9 +8,23 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WitnessDetails {
 
+    private String witnessPartyId;
     private String witnessName;
+    private String witnessFamilyName;
+
+    public WitnessDetails() {
+    }
+
+    public WitnessDetails(String witnessName) {
+        this.witnessName = witnessName;
+    }
+
+    public WitnessDetails(String witnessName, String witnessFamilyName) {
+        this.witnessName = witnessName;
+        this.witnessFamilyName = witnessFamilyName;
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7195


### Change description ###
- add the witnessPartyId and witnessFamilyName in WitnessDetails, because some appeal type will cause the exception in ia-home-office-integration-api when user trigger "list the case" event
- temporary suppress the CVE problem



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
