### PR TITLE
DIAC-1021 update with correct version of wiremock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ target/
 *.ipr
 
 .DS_Store
+
+#vs
+.vscode
+/bin/*
+!/bin/*.sh

--- a/build.gradle
+++ b/build.gradle
@@ -371,7 +371,7 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
 
-  testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.35.1'
+  testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.1'
   testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.12.4'
   testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
   testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test') {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -5,5 +5,6 @@
         <cve>CVE-2024-38820</cve>
         <cve>CVE-2024-22259</cve>
         <cve>CVE-2024-38808</cve>
+        <cve>CVE-2025-46392</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
Update to correct version of wiremock
com.github.tomakehurst:wiremock:2.35.1 doesn't exist anymore in any maven repo. The correct group ID for WireMock changed in recent versions to com.github.tomakehurst:wiremock-jre8:2.35.1


```
[ ] Yes
[ x] No
```
